### PR TITLE
feat: add Black Friday integration

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -37,6 +37,7 @@ class Admin {
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_fse_design_pack_notice' ) );
 		add_action( 'wp_ajax_fork_dismiss_design_pack_notice', array( $this, 'remove_design_pack_notice' ) );
+		add_filter( 'themeisle_sdk_blackfriday_data', array( $this, 'add_black_friday_data' ) );
 	}
 
 	/**
@@ -337,5 +338,32 @@ class Admin {
 			2 
 		);
 		do_action( 'themeisle_internal_page', FORK_PRODUCT_SLUG, $screen->id );
+	}
+
+	/**
+	 * Add Black Friday data.
+	 *
+	 * @param array $configs The configuration array for the loaded products.
+	 *
+	 * @return array
+	 */
+	public function add_black_friday_data( $configs ) {
+		$config = $configs['default'];
+
+		// translators: %1$s - plugin name, %2$s - HTML tag, %3$s - discount.
+		$message_template = __( 'Enhance %1$s with %2$s– up to %3$s OFF in our biggest sale of the year. Limited time only.', 'fork' );
+
+		$config['dismiss']  = true; // Note: Allow dismiss since it appears on `/wp-admin`.
+		$config['message']  = sprintf( $message_template, 'Fork', 'Otter Blocks Pro', '70%' );
+		$config['sale_url'] = add_query_arg(
+			array(
+				'utm_term' => 'free',
+			),
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-bf', 'bfcm', 'fork' ) )
+		);
+
+		$configs[ FORK_PRODUCT_SLUG ] = $config;
+
+		return $configs;
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Black Friday integration.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->

![CleanShot 2025-05-16 at 16 35 45@2x](https://github.com/user-attachments/assets/372abd3b-2995-436f-a5f5-7cc37a0bae6c)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- [USE THIS SDK VERSION as PLUGIN](https://github.com/Codeinwp/themeisle-sdk-main/pull/295#issuecomment-2858057844)
- Alter the date to fall into the Black Friday sales period.

You can use this hook to alternate it:

```php
add_filter(
	'themeisle_sdk_current_date',
	function() {
		return new DateTime( '2025-11-26' );
	}
);
```

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->